### PR TITLE
Updates pda claim to email verification endpoint

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
 
   val resolvers = Seq(
     "Atlassian Releases" at "https://maven.atlassian.com/public/",
-    "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases",
+    "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
     "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/")
 
   object Library {

--- a/src/main/scala/org/hatdex/hat/api/models/ApiAuthentication.scala
+++ b/src/main/scala/org/hatdex/hat/api/models/ApiAuthentication.scala
@@ -1,0 +1,11 @@
+package org.hatdex.hat.api.models
+
+import play.api.libs.json._
+
+case class PdaEmailVerificationRequest(
+    email: String,
+    applicationId: String)
+
+object ApiAuthenticationFormats {
+  implicit val passwordResetRequestFormat: OFormat[PdaEmailVerificationRequest] = Json.format[PdaEmailVerificationRequest]
+}


### PR DESCRIPTION
Updates PDA claim endpoint in sync with the changes applied to HAT web server in the PR https://github.com/dataswift/HAT2.0/pull/170.

I have purposefully did not bump up library version as the changes are complementary with PR https://github.com/dataswift/hat-client-scala-play/pull/29.